### PR TITLE
Change the export format to be keyed by namespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "headless-block-components",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "headless-block-components",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "peerDependencies": {
-    "react": "16.0.0"
+    "react": "16.13.1"
   },
   "devDependencies": {
     "@wordpress/i18n": "3.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headless-block-components",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Block components for the WordPress block editor and headless.",
   "author": "kienstra",
   "license": "GPL-2.0-or-later",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headless-block-components",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Block components for the WordPress block editor and headless.",
   "author": "kienstra",
   "license": "GPL-2.0-or-later",
@@ -50,5 +50,13 @@
   },
   "files": [
     "dist"
+  ],
+  "contributors": [
+    {
+      "name": "Ryan Kienstra"
+    },
+    {
+      "name": "Phil Johnston"
+    }
   ]
 }

--- a/src/components/email-opt-in.js
+++ b/src/components/email-opt-in.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react'
+
+/**
+ * @typedef {Object} ExampleProps
+ * @property {Object} [attrs] The block attributes available on the front-end.
+ * @property {Object} [attributes] The block attributes available in the block editor.
+ */
+
+/**
+ * An example block component.
+ *
+ * @param {ExampleProps} props
+ * @return {React.ReactElement} An example preview component.
+ */
+const EmailOptIn = (props) =>{
+  const attributes = props.attrs ? props.attrs : props.attributes
+  const [isSubmitted, setIsSubmitted] = React.useState(false);
+
+  return (
+    <div>
+      <h1>{attributes.heading}</h1>
+      {isSubmitted ? (
+        <p>{attributes['submission-message']}</p>
+      ) : (
+        <div>
+          <p>{attributes['main-copy']}</p>
+          <input type='email' />
+          <button
+            onClick={() => {
+              setIsSubmitted((isSubmitted) => !isSubmitted)
+            }}
+          >
+            {attributes['button-text']}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default EmailOptIn

--- a/src/components/example.js
+++ b/src/components/example.js
@@ -10,7 +10,8 @@ import { __ } from '@wordpress/i18n'
 
 /**
  * @typedef {Object} ExampleProps
- * @property {Object} attributes The block attributes.
+ * @property {Object} attributes The block attributes available in the block editor.
+ * @property {Object} attrs The block attributes available on the front-end.
  */
 
 /**
@@ -19,17 +20,21 @@ import { __ } from '@wordpress/i18n'
  * @param {ExampleProps} props
  * @return {React.ReactElement} An example preview component.
  */
-const Example = ({ attributes }) => (
-  <div>
-    <p>{__('This is an alternate preview component', 'headless-blocks')}</p>
-    <p>
-      {__(
-        'Here is the value of the new-field attribute, if it exists:',
-        'headless-blocks'
-      )}
-    </p>
-    <p>{attributes['new-field']}</p>
-  </div>
-)
+const Example = (props) => {
+  const attributes = props.attrs ? props.attrs : props.attributes;
+
+  return (
+    <div>
+      <p>{__('This is an alternate preview component', 'headless-blocks')}</p>
+      <p>
+        {__(
+          'Here is the value of the new-field attribute, if it exists:',
+          'headless-blocks'
+        )}
+      </p>
+      <p>{attributes['new-field']}</p>
+    </div>
+  );
+}
 
 export default Example

--- a/src/components/example.js
+++ b/src/components/example.js
@@ -21,12 +21,7 @@ import { __ } from '@wordpress/i18n'
  */
 const Example = ({ attributes }) => (
   <div>
-    <p>
-      {__(
-        'This is an alternate preview component',
-        'headless-blocks'
-      )}
-    </p>
+    <p>{__('This is an alternate preview component', 'headless-blocks')}</p>
     <p>
       {__(
         'Here is the value of the new-field attribute, if it exists:',

--- a/src/components/example.js
+++ b/src/components/example.js
@@ -21,7 +21,7 @@ import { __ } from '@wordpress/i18n'
  * @return {React.ReactElement} An example preview component.
  */
 const Example = (props) => {
-  const attributes = props.attrs ? props.attrs : props.attributes;
+  const attributes = props.attrs ? props.attrs : props.attributes
 
   return (
     <div>
@@ -34,7 +34,7 @@ const Example = (props) => {
       </p>
       <p>{attributes['new-field']}</p>
     </div>
-  );
+  )
 }
 
 export default Example

--- a/src/components/example.js
+++ b/src/components/example.js
@@ -10,8 +10,8 @@ import { __ } from '@wordpress/i18n'
 
 /**
  * @typedef {Object} ExampleProps
- * @property {Object} attributes The block attributes available in the block editor.
- * @property {Object} attrs The block attributes available on the front-end.
+ * @property {Object} [attrs] The block attributes available on the front-end.
+ * @property {Object} [attributes] The block attributes available in the block editor.
  */
 
 /**

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,1 +1,6 @@
-export { default as Example } from './example'
+import { Example } from './example'
+
+const namespace = 'genesis-custom-blocks'
+export default {
+  [`${namespace}/example`]: Example
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,8 +1,10 @@
-import { default as Example } from './example'
+import Example from './example'
+import EmailOptIn from './email-opt-in'
 
 const namespace = 'genesis-custom-blocks'
 const blockComponents = {
-  [`${namespace}/example`]: Example
+  [`${namespace}/example`]: Example,
+  [`${namespace}/email-opt-in`]: EmailOptIn
 }
 
-export default blockComponents;
+export default blockComponents

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,6 +1,8 @@
-import { Example } from './example'
+import { default as Example } from './example'
 
 const namespace = 'genesis-custom-blocks'
-export default {
+const blockComponents = {
   [`${namespace}/example`]: Example
 }
+
+export default blockComponents;

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,1 @@
-export * from './components'
+export { default as blockComponents } from './components'


### PR DESCRIPTION
Now, consuming files can get the components by the full block name.

```
import { blockComponents } from 'headless-block-components';
```

`blockComponents` will have the format:

```js
{
    'block-namespace/block-name': BlockComponent, 
    'block-namespace/other-block-name': OtherBlockComponent,
}

```
...where `BlockComponent` and `OtherBlockComponent` are React components.
